### PR TITLE
Make workers pass acceptlock

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -559,14 +559,7 @@ kore_worker_acceptlock_release(u_int64_t now)
 	if (worker->has_lock != 1)
 		return (0);
 
-	if (worker_active_connections < worker_max_connections) {
-#if !defined(KORE_NO_HTTP)
-		if (http_request_count < http_request_limit)
-			return (0);
-#else
-		return (0);
-#endif
-	}
+
 
 #if defined(WORKER_DEBUG)
 	kore_log(LOG_DEBUG, "worker busy, releasing lock");


### PR DESCRIPTION
The acceptlock is currently only passed when a worker reaches max connections (default: 250),
this prevents the connections being distributed evenly among the workers.

This also complicates testing of applications that communicate between the workers.
And would perhaps leave workers/cores to idle, while increasing the response time in all requests in the busy worker.